### PR TITLE
Feat/insights

### DIFF
--- a/src/shared/components/Insight/index.jsx
+++ b/src/shared/components/Insight/index.jsx
@@ -40,6 +40,7 @@ export default function Insight({
       newData,
       oldAggregates,
       newAggregates,
+      config,
    } = useInsights(identifier, {
       includeTableData: includeTable,
       includeChartData: includeChart,
@@ -85,7 +86,7 @@ export default function Insight({
                {isDiff ? <CounterBar aggregates={newAggregates} /> : null}
                <CounterBar aggregates={oldAggregates} />
             </div>
-            {includeChart ? (
+            {(config && config.includeChart) || includeChart ? (
                <HeroCharts
                   allowedCharts={allowedCharts}
                   oldData={oldData}
@@ -95,7 +96,7 @@ export default function Insight({
             ) : null}
 
             <StyledGrid isDiff={isDiff}>
-               {includeChart ? (
+               {(config && config.includeChart) || includeChart ? (
                   <FlexCharts
                      allowedCharts={allowedCharts}
                      oldData={oldData}
@@ -104,23 +105,23 @@ export default function Insight({
                   />
                ) : null}
             </StyledGrid>
-            <Flex container>
-               {isDiff ? (
-                  <ReactTabulator
-                     columns={[]}
-                     options={tableConfig}
-                     data={newTableData.length ? newTableData : oldTableData}
-                  />
-               ) : null}
+            {(config && config.includeTable) || includeTable ? (
+               <Flex container>
+                  {isDiff ? (
+                     <ReactTabulator
+                        columns={[]}
+                        options={tableConfig}
+                        data={newTableData.length ? newTableData : oldTableData}
+                     />
+                  ) : null}
 
-               {includeTable && (
                   <ReactTabulator
                      columns={[]}
                      options={tableConfig}
                      data={oldTableData}
                   />
-               )}
-            </Flex>
+               </Flex>
+            ) : null}
          </StyledContainer>
       </>
    )

--- a/src/shared/hooks/useInsights.js
+++ b/src/shared/hooks/useInsights.js
@@ -69,6 +69,7 @@ export const useInsights = (
             id: null,
             filters: null,
             defaultOptions: {},
+            config: {},
          },
       } = {},
    } = useQuery(GET_INSIGHT, {
@@ -133,6 +134,7 @@ export const useInsights = (
       switches: variableSwitches,
       optionVariables: variableOptions,
       options: whereObject,
+      config: insight.config,
       updateSwitches: setVariableSwitches,
       updateOptions,
       oldAggregates,
@@ -152,6 +154,7 @@ export const GET_INSIGHT = gql`
          identifier
          availableOptions
          filters
+         config
          defaultOptions
          query
          switches


### PR DESCRIPTION
insights table now has `config` field (jsonb) for configuring the `includeTable` and the `includeChart` option.

### What is the current behavior?

- show chart/table can only be configured by passing the props to the `<Insight />`


### What is the new behavior if this PR is merged?

- now `<Insight />` reads the config field in the insights table. The schema of the `config` field for now is :

```json
{
  "inlcudeTable": false,
  "includeChart": true,
}
```

- if either of the config object or the props passed to the component is true then only render the chart/table.

##### This PR has:

-  [x] Commit messages that are correctly formatted
-  [x] Feature list updated for newly introduced code

This PR is a small change.

**Developers**

@siddhantk232 
