### PR TITLE
feat: schemaVariables

### DIFF
--- a/src/shared/components/Insight/index.jsx
+++ b/src/shared/components/Insight/index.jsx
@@ -20,6 +20,7 @@ export default function Insight({
    includeTable = true,
    includeChart = false,
    identifier = '',
+   where = {},
    limit,
    order,
    variables = {},
@@ -44,6 +45,7 @@ export default function Insight({
    } = useInsights(identifier, {
       includeTableData: includeTable,
       includeChartData: includeChart,
+      where,
       limit,
       order,
       variables,

--- a/src/shared/components/Insight/index.jsx
+++ b/src/shared/components/Insight/index.jsx
@@ -14,15 +14,15 @@ import { tableConfig } from './tableConfig'
 
 /**
  *
- * @param {{includeTable: boolean, includeChart: boolean, identifier: string, where: {}, limit: number, order: {}}} props
+ * @param {{includeTable: boolean, includeChart: boolean, identifier: string, where: {}, limit: number, order: {}, variables: {}}} props
  */
 export default function Insight({
    includeTable = true,
    includeChart = false,
    identifier = '',
-   where = {},
    limit,
    order,
+   variables = {},
 }) {
    const [isDiff, setIsDiff] = useState(false)
 
@@ -44,9 +44,9 @@ export default function Insight({
    } = useInsights(identifier, {
       includeTableData: includeTable,
       includeChartData: includeChart,
-      where,
       limit,
       order,
+      variables,
    })
 
    return (

--- a/src/shared/hooks/useInsights.js
+++ b/src/shared/hooks/useInsights.js
@@ -120,7 +120,7 @@ export const useInsights = (
          options: {
             ...insight.defaultOptions,
             // merge variableOptions and schemaVariables, schemaVariables will overwrite any filter values in variableOptions
-            ...merge(variableOptions, schemaVariables),
+            ...merge(variableOptions, schemaVariables, options.where),
          },
          limit: options.limit,
          orderBy: options.order,

--- a/src/shared/hooks/useInsights.js
+++ b/src/shared/hooks/useInsights.js
@@ -1,8 +1,13 @@
 import { useQuery } from '@apollo/react-hooks'
 import gql from 'graphql-tag'
-import { useState } from 'react'
-import { buildOptions, transformer } from '../utils/insight_utils'
 import { merge } from 'lodash'
+import { useState } from 'react'
+import {
+   buildOptions,
+   buildOptionVariables,
+   transformer,
+} from '../utils/insight_utils'
+import { isObject } from '../utils/isObject'
 
 function onError(error) {
    console.log(error)
@@ -69,6 +74,7 @@ export const useInsights = (
             id: null,
             filters: null,
             defaultOptions: {},
+            schemaVariables: null,
             config: {},
          },
       } = {},
@@ -87,13 +93,34 @@ export const useInsights = (
       gqlQuery = buildQuery(insight.query)
    }
 
+   let tempFillers = null
+
+   // flatten schema variable till keys starting with _
+   if (insight.schemaVariables)
+      tempFillers = buildOptions(insight.schemaVariables)
+
+   // loop through the tempFillers and replace values starting with $ with the corresponding values in the options.variables object
+   if (tempFillers && isObject(tempFillers))
+      for (const key in tempFillers) {
+         for (const subKey in tempFillers[key]) {
+            if (`${tempFillers[key][subKey] || ''}`.startsWith('$')) {
+               const tempKey = tempFillers[key][subKey].slice(1)
+               tempFillers[key][subKey] = options.variables[tempKey]
+            }
+         }
+      }
+
+   //  unflatten the tempFillers to pass in the query
+   const schemaVariables = buildOptionVariables(tempFillers || {})
+
    const { loading } = useQuery(gqlQuery, {
       onError,
       variables: {
          ...variableSwitches,
          options: {
             ...insight.defaultOptions,
-            ...merge(variableOptions, options.where),
+            // merge variableOptions and schemaVariables, schemaVariables will overwrite any filter values in variableOptions
+            ...merge(variableOptions, schemaVariables),
          },
          limit: options.limit,
          orderBy: options.order,
@@ -156,6 +183,7 @@ export const GET_INSIGHT = gql`
          filters
          config
          defaultOptions
+         schemaVariables
          query
          switches
          charts {


### PR DESCRIPTION
feat: schemaVariables

#### Other information
This feature lets the query writer define the variables in the schemaVariables (JSONB) field in the insights table. Later the variables defined in the schemaVariables field can be passed in the insights component using the `variables` props which takes an object where the key is the variable name (without `$`) and the value must be of the type specified by the graphql schema.

##### This PR has:

-  [x] Commit messages that are correctly formatted
-  [ ] Feature list updated for newly introduced code

This PR is a feature

**Developers**
@siddhantk232 

