### PR TITLE
feat: insight dashboard

### DIFF
--- a/src/shared/components/InsightDashboard/index.js
+++ b/src/shared/components/InsightDashboard/index.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import { INSIGHT } from './query'
+import { useQuery } from '@apollo/react-hooks'
+import Insight from '../Insight'
+
+export default function InsightDashboard({ appTitle, moduleTitle, variables }) {
+   const { data: { insights_insights: insights = [] } = {} } = useQuery(
+      INSIGHT,
+      {
+         variables: {
+            options: {
+               isActive: { _eq: true },
+               apps_modules: {
+                  appTitle: { _eq: appTitle },
+                  moduleTitle: { _eq: moduleTitle },
+               },
+            },
+         },
+         onError: error => {
+            console.log(error)
+         },
+      }
+   )
+   return (
+      <div>
+         {insights.map(insight => {
+            return (
+               <Insight
+                  key={insight.identifier}
+                  identifier={insight.identifier}
+                  variables={variables}
+               />
+            )
+         })}
+      </div>
+   )
+}

--- a/src/shared/components/InsightDashboard/query.js
+++ b/src/shared/components/InsightDashboard/query.js
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag'
+
+export const INSIGHT = gql`
+   query INSIGHT($options: insights_insights_bool_exp!) {
+      insights_insights(where: $options) {
+         identifier
+      }
+   }
+`

--- a/src/shared/components/index.js
+++ b/src/shared/components/index.js
@@ -6,6 +6,7 @@ import HorizontalCard from './HorizontalCard'
 import Conditions from './Conditions'
 import ErrorBoundary from './ErrorBoundary'
 import NutritionTunnel from './NutritionTunnel'
+import InsightDashboard from './InsightDashboard'
 
 export {
    Lang,
@@ -16,6 +17,7 @@ export {
    Conditions,
    ErrorBoundary,
    NutritionTunnel,
+   InsightDashboard,
 }
 export * from './AssetUploader'
 export * from './InlineLoader'


### PR DESCRIPTION
**This PR includes:**

- Insight Dashboard component 

**What is the new behavior if this PR is merged?**

- Insight component can be used by just passing `appName`, `moduleName `and variables.

- No need to use query for getting insight identifier

- Specific insight  will be shown for the specific app and for specific module in app