### PR TITLE
fix(order): list not showing on tab switch

### DIFF
--- a/src/apps/order/graphql/queries.js
+++ b/src/apps/order/graphql/queries.js
@@ -151,23 +151,30 @@ export const ORDERS = gql`
             isAssembled
             assemblyStatus
             assemblyStation {
+               id
                name
             }
             comboProduct {
+               id
                name
             }
             comboProductComponent {
+               id
                label
             }
             orderSachets {
+               id
                status
                isAssembled
             }
             simpleRecipeProduct {
+               id
                name
             }
             simpleRecipeProductOption {
+               id
                simpleRecipeYield {
+                  id
                   yield
                }
             }
@@ -178,9 +185,11 @@ export const ORDERS = gql`
             isAssembled
             assemblyStatus
             simpleRecipeProduct {
+               id
                name
             }
             assemblyStation {
+               id
                name
             }
             comboProduct {
@@ -192,10 +201,13 @@ export const ORDERS = gql`
                label
             }
             simpleRecipeProduct {
+               id
                name
             }
             simpleRecipeProductOption {
+               id
                simpleRecipeYield {
+                  id
                   yield
                }
             }
@@ -205,22 +217,28 @@ export const ORDERS = gql`
             price
             isAssembled
             inventoryProduct {
+               id
                name
             }
             comboProduct {
+               id
                name
             }
             comboProductComponent {
+               id
                label
             }
             assemblyStation {
+               id
                name
             }
             assemblyStatus
             customizableProduct {
+               id
                name
             }
             inventoryProductOption {
+               id
                quantity
                label
             }


### PR DESCRIPTION
### What is the current behavior?
Orders list doesn't show up on switching tabs

### What is the new behavior if this PR is merged?
Orders list do show up on switching tabs now

##### This PR has:

-  [x] Commit messages that are correctly formatted
-  [x] Feature list updated for newly introduced code

**Developers**
@prvnbist 
