### PR TITLE
feat/insights

### DIFF
--- a/src/apps/insights/views/RecipeInsight/index.jsx
+++ b/src/apps/insights/views/RecipeInsight/index.jsx
@@ -22,14 +22,18 @@ const ReferralPlansListing = () => {
       <StyledWrapper>
          {insights.map(insight => {
             return (
-               <Flex width="calc(100% - 64px)" margin="0 auto">
+               <Flex
+                  key={insight.identifier}
+                  width="calc(100% - 64px)"
+                  margin="0 auto"
+               >
                   <Insight
-                     key={insight.identifier}
                      identifier={insight.identifier}
                      includeChart
                      // where={{ amountPaid: { _lte: 2 } }}
                      // limit={2}
                      // order={{ amountPaid: 'desc' }}
+                     variables={{ amountVar: 90 }}
                   />
                </Flex>
             )

--- a/src/shared/components/Insight/Filters/Filters.jsx
+++ b/src/shared/components/Insight/Filters/Filters.jsx
@@ -224,7 +224,7 @@ function Filter({
       <>
          <Spacer xAxis size="16px" />
          <Dropdown
-            title={fromMixed(filter)}
+            title={fromMixed(filter.split('  ')[1])}
             withIcon
             show={show}
             setShow={setShow}

--- a/src/shared/components/Insight/Option.jsx
+++ b/src/shared/components/Insight/Option.jsx
@@ -35,7 +35,7 @@ export default function Option({
    isDiff,
 }) {
    const [submenu, setSubmenu] = useState('main')
-   const [optionsState, setOptionsState] = useState(state)
+   const [optionsState, setOptionsState] = useState({})
    const [newOptionsState, setNewOptionsState] = useState({})
    const [currentOptions, setCurrentOptions] = useState({})
    const [currentNewOptions, setCurrentNewOptions] = useState({})
@@ -54,6 +54,7 @@ export default function Option({
       const newOptions = isNewOption
          ? buildOptionVariables(newOptionsState)
          : buildOptionVariables(optionsState)
+
       updateOptions(isNewOption)(newOptions)
       setShow(false)
 
@@ -271,7 +272,7 @@ export default function Option({
                            onClick={() => setDropdownView(option)}
                            key={option}
                         >
-                           {fromMixed(option)}
+                           {fromMixed(option.split('  ')[1])}
                         </DropdownItem>
                      )
                   })}
@@ -418,7 +419,8 @@ const AppliedFilters = React.memo(
                               if (currentNewOptions[option][key])
                                  return (
                                     <Tag color="primary" key={option + i}>
-                                       {fromMixed(option)}: {optionsMap[key]}{' '}
+                                       {fromMixed(option.split('  ')[1])}:{' '}
+                                       {optionsMap[key]}{' '}
                                        {currentNewOptions[option][key]}
                                     </Tag>
                                  )
@@ -430,7 +432,7 @@ const AppliedFilters = React.memo(
                            if (currentNewOptions[option][key])
                               return (
                                  <Tag color="primary" key={option + i}>
-                                    {optionsMap[option][key]}{' '}
+                                    {optionsMap['created_at'][key]}{' '}
                                     {dateFmt.format(
                                        new Date(currentNewOptions[option][key])
                                     )}
@@ -449,7 +451,8 @@ const AppliedFilters = React.memo(
                            if (currentOptions[option][key])
                               return (
                                  <Tag color="primary" key={option + i}>
-                                    {fromMixed(option)}: {optionsMap[key]}{' '}
+                                    {fromMixed(option.split('  ')[1])}:{' '}
+                                    {optionsMap[key]}{' '}
                                     {currentOptions[option][key]}
                                  </Tag>
                               )
@@ -460,7 +463,7 @@ const AppliedFilters = React.memo(
                      if (currentOptions[option][key])
                         return (
                            <Tag color="primary" key={option + i}>
-                              {optionsMap[option][key]}{' '}
+                              {optionsMap['created_at'][key]}{' '}
                               {dateFmt.format(
                                  new Date(currentOptions[option][key])
                               )}

--- a/src/shared/components/Insight/index.jsx
+++ b/src/shared/components/Insight/index.jsx
@@ -1,5 +1,5 @@
 import { ReactTabulator } from '@dailykit/react-tabulator'
-import { Filler, Flex, Form } from '@dailykit/ui'
+import { Flex, Form } from '@dailykit/ui'
 import React, { useState } from 'react'
 import 'react-tabulator/css/bootstrap/tabulator_bootstrap.min.css'
 import 'react-tabulator/lib/styles.css'
@@ -57,7 +57,6 @@ export default function Insight({
 
    if (loading) return <InlineLoader />
    if (error) return <ErrorState />
-   if (empty) return <Filler />
 
    return (
       <>

--- a/src/shared/hooks/useInsights.js
+++ b/src/shared/hooks/useInsights.js
@@ -115,11 +115,8 @@ export const useInsights = (
    const { error: insightError } = useQuery(gqlQuery, {
       variables: {
          ...variableSwitches,
-         options: {
-            ...insight.defaultOptions,
-            // merge variableOptions and schemaVariables, schemaVariables will overwrite any filter values in variableOptions
-            ...merge(variableOptions, schemaVariables, options.where),
-         },
+         // merge variableOptions and schemaVariables, schemaVariables will overwrite any filter values in variableOptions
+         ...merge(variableOptions, schemaVariables, options.where),
          limit: options.limit,
          orderBy: options.order,
       },


### PR DESCRIPTION

<!-- A short description can be included here -->
<!-- Please ensure that reviewers are assigned -->

### What is the current behavior?

only one variable can be used with the insight query.

<!-- You can link to an open issue here -->

### What is the new behavior if this PR is merged?

now, variable(s) of any name can be used in one query.
This will allow us to use schemaVariables and filters for any variable in 
the query.
This solves the problem of using schemaVariables and filters in multiple 
nested queries.

#### Other information
- change: removed filler when no chart/table data
- change: not wrapping variables in `options`
- change: ignore query variable name when rendering
- feat: schemaVariables example

##### This PR has:

-  [x] Commit messages that are correctly formatted

This PR is a small change/feat<!-- REQUIRED: replace this comment with one of ["small change", "feature", "compatibility breaking update", "non-versioned change"] -->

**Developers**
@siddhantk232

