### PR TITLE
feat(responsiveness):make settings app's  home , listing responsive

### DIFF
--- a/src/apps/settings/sections/Sidebar/styled.js
+++ b/src/apps/settings/sections/Sidebar/styled.js
@@ -11,6 +11,9 @@ export const StyledSidebar = styled.aside(
       z-index: 1000;
       transition: 0.3s ease-in-out;
       transform: translateX(${visible ? '0' : '-240px'});
+      @media screen and (max-width: 767px) {
+         width: ${visible ? '100%' : null};
+      }
    `
 )
 

--- a/src/apps/settings/views/Home/styled.js
+++ b/src/apps/settings/views/Home/styled.js
@@ -28,4 +28,7 @@ export const StyledCardList = styled.ul`
    @media (max-width: 567px) {
       grid-template-columns: 1fr;
    }
+   div {
+      width: 100%;
+   }
 `

--- a/src/apps/settings/views/Listings/DevicesListing/index.jsx
+++ b/src/apps/settings/views/Listings/DevicesListing/index.jsx
@@ -35,6 +35,7 @@ import { logger } from '../../../../../shared/utils'
 import { DEVICES, PRINT_JOB } from '../../../graphql'
 import { PrinterIcon } from '../../../../../shared/assets/icons'
 import { InlineLoader, Tooltip } from '../../../../../shared/components'
+import { ResponsiveFlex } from '../styled'
 
 const DevicesListing = () => {
    const { tab, addTab } = useTabs()
@@ -68,7 +69,7 @@ const DevicesListing = () => {
    }, [tab, addTab])
 
    return (
-      <Flex width="calc(100vw - 64px)" maxWidth="1280px" margin="0 auto">
+      <ResponsiveFlex maxWidth="1280px" margin="0 auto">
          <Flex
             container
             as="header"
@@ -249,7 +250,7 @@ const DevicesListing = () => {
                <PrintTunnel closeTunnel={closeTunnel} />
             </Tunnel>
          </Tunnels>
-      </Flex>
+      </ResponsiveFlex>
    )
 }
 

--- a/src/apps/settings/views/Listings/MasterList/index.jsx
+++ b/src/apps/settings/views/Listings/MasterList/index.jsx
@@ -9,6 +9,7 @@ import { MASTER } from '../../../graphql'
 import { useTabs } from '../../../context'
 import { Tooltip } from '../../../../../shared/components'
 import { useTooltip } from '../../../../../shared/providers'
+import { ResponsiveFlex } from '../styled'
 
 const address = 'apps.settings.views.listings.masterlist.'
 
@@ -123,7 +124,7 @@ const MasterList = () => {
    }, [tab, addTab])
 
    return (
-      <Flex margin="0 auto" maxWidth="1280px" width="calc(100vw - 64px)">
+      <ResponsiveFlex margin="0 auto" maxWidth="1280px">
          <Flex
             container
             as="header"
@@ -143,7 +144,7 @@ const MasterList = () => {
             rowClick={rowClick}
             options={tableOptions}
          />
-      </Flex>
+      </ResponsiveFlex>
    )
 }
 

--- a/src/apps/settings/views/Listings/RolesListing/index.jsx
+++ b/src/apps/settings/views/Listings/RolesListing/index.jsx
@@ -11,6 +11,7 @@ import { useTabs } from '../../../context'
 import { logger } from '../../../../../shared/utils'
 import { useTooltip } from '../../../../../shared/providers'
 import { InlineLoader, Tooltip } from '../../../../../shared/components'
+import { ResponsiveFlex } from '../styled'
 
 const RolesListing = () => {
    const tableRef = React.useRef()
@@ -65,7 +66,7 @@ const RolesListing = () => {
    ]
 
    return (
-      <Flex margin="0 auto" maxWidth="1280px" width="calc(100vw - 64px)">
+      <ResponsiveFlex margin="0 auto" maxWidth="1280px">
          <Flex
             container
             as="header"
@@ -91,7 +92,7 @@ const RolesListing = () => {
                }}
             />
          )}
-      </Flex>
+      </ResponsiveFlex>
    )
 }
 

--- a/src/apps/settings/views/Listings/StationsListing/index.jsx
+++ b/src/apps/settings/views/Listings/StationsListing/index.jsx
@@ -12,6 +12,7 @@ import { logger } from '../../../../../shared/utils'
 import { useTooltip } from '../../../../../shared/providers'
 import { InlineLoader, Tooltip } from '../../../../../shared/components'
 import { AddIcon, DeleteIcon } from '../../../../../shared/assets/icons'
+import { ResponsiveFlex } from '../styled'
 
 const StationsListing = () => {
    const { tooltip } = useTooltip()
@@ -83,7 +84,7 @@ const StationsListing = () => {
    }, [tab, addTab])
 
    return (
-      <Flex margin="0 auto" maxWidth="1280px" width="calc(100vw - 64px)">
+      <ResponsiveFlex margin="0 auto" maxWidth="1280px">
          <Flex
             container
             as="header"
@@ -126,7 +127,7 @@ const StationsListing = () => {
                }}
             />
          )}
-      </Flex>
+      </ResponsiveFlex>
    )
 }
 

--- a/src/apps/settings/views/Listings/UsersListing/index.jsx
+++ b/src/apps/settings/views/Listings/UsersListing/index.jsx
@@ -16,6 +16,7 @@ import {
    InlineLoader,
    Tooltip,
 } from '../../../../../shared/components'
+import { ResponsiveFlex } from '../styled'
 
 const UsersListing = () => {
    const tableRef = React.useRef()
@@ -65,6 +66,7 @@ const UsersListing = () => {
          field: 'firstName',
          headerFilter: true,
          cssClass: 'cell',
+         width: 100,
          cellClick: (e, cell) => rowClick(e, cell),
          formatter: cell =>
             `${cell.getData()?.firstName || ''} ${
@@ -81,6 +83,7 @@ const UsersListing = () => {
          title: 'Email',
          field: 'email',
          headerFilter: true,
+         width: 100,
          headerTooltip: column => {
             const identifier = 'user_listing_column_email'
             return (
@@ -111,7 +114,7 @@ const UsersListing = () => {
    }, [tab, addTab])
 
    return (
-      <Flex margin="0 auto" maxWidth="1280px" width="calc(100vw - 64px)">
+      <ResponsiveFlex margin="0 auto" maxWidth="1280px">
          <Flex
             container
             as="header"
@@ -152,7 +155,7 @@ const UsersListing = () => {
                )}
             </>
          )}
-      </Flex>
+      </ResponsiveFlex>
    )
 }
 

--- a/src/apps/settings/views/Listings/styled.js
+++ b/src/apps/settings/views/Listings/styled.js
@@ -1,3 +1,4 @@
+import { Flex } from '@dailykit/ui'
 import styled from 'styled-components'
 
 export const StyledBadge = styled.span`
@@ -6,4 +7,12 @@ export const StyledBadge = styled.span`
    border-radius: 24px;
    padding: 0 6px;
    font-size: 14px;
+`
+export const ResponsiveFlex = styled(Flex)`
+   @media screen and (max-width: 767px) {
+      width: calc(100vw - 32px);
+   }
+   @media screen and (min-width: 768px) {
+      width: calc(100vw - 64px);
+   }
 `


### PR DESCRIPTION
<!-- A short description can be included here -->
Settings apps home and listing responsive 

<!-- Please ensure that reviewers are assigned -->

### What is the current behavior?
Settings apps home and listing are not responsive 
<!-- You can link to an open issue here -->

### What is the new behavior if this PR is merged?
Settings apps home and listing should be  responsive 

#### Other information

##### This PR has:

-  [x] Commit messages that are correctly formatted
-  [x] Feature list updated for newly introduced code



**Developers**
@FAsami 
